### PR TITLE
Add support for sharpResizeOptions

### DIFF
--- a/src/global-options.js
+++ b/src/global-options.js
@@ -28,6 +28,7 @@ export const getDefaults = () => ({
   sharpPngOptions: {}, // options passed to the Sharp png output method
   sharpJpegOptions: {}, // options passed to the Sharp jpeg output method
   sharpAvifOptions: {}, // options passed to the Sharp avif output method
+  sharpResizeOptions: undefined, // options passed to the Sharp resize method
 
   formatHooks: {
     svg: svgHook,

--- a/src/global-options.js
+++ b/src/global-options.js
@@ -28,7 +28,7 @@ export const getDefaults = () => ({
   sharpPngOptions: {}, // options passed to the Sharp png output method
   sharpJpegOptions: {}, // options passed to the Sharp jpeg output method
   sharpAvifOptions: {}, // options passed to the Sharp avif output method
-  sharpResizeOptions: undefined, // options passed to the Sharp resize method
+  sharpResizeOptions: {}, // options passed to the Sharp resize method
 
   formatHooks: {
     svg: svgHook,

--- a/src/image.js
+++ b/src/image.js
@@ -358,24 +358,16 @@ export default class Image {
     return {};
   }
 
-  static getSharpResizeOptionsWithoutDimensions(sharpResizeOptions = {}) {
-    let options = {
-      ...sharpResizeOptions,
+  getSharpResizeOptions(stat, metadata) {
+    let resizeOptions = {
+      ...this.options.sharpResizeOptions,
     };
 
     // Eleventy Image owns output dimensions. Allowing these here would make
     // returned metadata disagree with the output image.
-    delete options.width;
-    delete options.height;
-
-    return options;
-  }
-
-  getSharpResizeOptions(stat, metadata) {
-    let resizeOptions = {
-      ...Image.getSharpResizeOptionsWithoutDimensions(this.options.sharpResizeOptions),
-      width: stat.width,
-    };
+    delete resizeOptions.width;
+    delete resizeOptions.height;
+    resizeOptions.width = stat.width;
 
     if(!("withoutEnlargement" in resizeOptions) && (metadata.format !== "svg" || !this.options.svgAllowUpscale)) {
       resizeOptions.withoutEnlargement = true;

--- a/src/image.js
+++ b/src/image.js
@@ -358,9 +358,24 @@ export default class Image {
     return {};
   }
 
+  static getNonDimensionSharpResizeOptions(sharpResizeOptions = {}) {
+    let options = {
+      ...sharpResizeOptions,
+    };
+
+    // Eleventy Image owns output dimensions and up/downscale policy. Allowing
+    // these here would make returned metadata disagree with the output image.
+    delete options.width;
+    delete options.height;
+    delete options.withoutEnlargement;
+    delete options.withoutReduction;
+
+    return options;
+  }
+
   getSharpResizeOptions(stat, metadata) {
     let resizeOptions = {
-      ...this.options.sharpResizeOptions,
+      ...Image.getNonDimensionSharpResizeOptions(this.options.sharpResizeOptions),
       width: stat.width,
     };
 
@@ -435,12 +450,17 @@ export default class Image {
     let hashObject = {};
     // The code currently assumes are keysToKeep are Object literals (see Util.getSortedObject)
     for(let key of keysToKeep) {
-      if(key === "sharpResizeOptions" && (!this.options[key] || Object.keys(this.options[key]).length === 0)) {
-        continue;
+      let options = this.options[key];
+
+      if(key === "sharpResizeOptions") {
+        options = Image.getNonDimensionSharpResizeOptions(options);
+        if(Object.keys(options).length === 0) {
+          continue;
+        }
       }
 
-      if(this.options[key]) {
-        hashObject[key] = Util.getSortedObject(this.options[key]);
+      if(options) {
+        hashObject[key] = Util.getSortedObject(options);
       }
     }
 

--- a/src/image.js
+++ b/src/image.js
@@ -359,9 +359,10 @@ export default class Image {
   }
 
   getSharpResizeOptions(stat, metadata) {
-    let resizeOptions = Object.assign({}, this.options.sharpResizeOptions, {
+    let resizeOptions = {
+      ...this.options.sharpResizeOptions,
       width: stat.width,
-    });
+    };
 
     if(metadata.format !== "svg" || !this.options.svgAllowUpscale) {
       resizeOptions.withoutEnlargement = true;

--- a/src/image.js
+++ b/src/image.js
@@ -452,11 +452,8 @@ export default class Image {
     for(let key of keysToKeep) {
       let options = this.options[key];
 
-      if(key === "sharpResizeOptions") {
-        options = Image.getNonDimensionSharpResizeOptions(options);
-        if(Object.keys(options).length === 0) {
-          continue;
-        }
+      if(key === "sharpResizeOptions" && Object.keys(options).length === 0) {
+        continue;
       }
 
       if(options) {

--- a/src/image.js
+++ b/src/image.js
@@ -358,28 +358,26 @@ export default class Image {
     return {};
   }
 
-  static getNonDimensionSharpResizeOptions(sharpResizeOptions = {}) {
+  static getSharpResizeOptionsWithoutDimensions(sharpResizeOptions = {}) {
     let options = {
       ...sharpResizeOptions,
     };
 
-    // Eleventy Image owns output dimensions and up/downscale policy. Allowing
-    // these here would make returned metadata disagree with the output image.
+    // Eleventy Image owns output dimensions. Allowing these here would make
+    // returned metadata disagree with the output image.
     delete options.width;
     delete options.height;
-    delete options.withoutEnlargement;
-    delete options.withoutReduction;
 
     return options;
   }
 
   getSharpResizeOptions(stat, metadata) {
     let resizeOptions = {
-      ...Image.getNonDimensionSharpResizeOptions(this.options.sharpResizeOptions),
+      ...Image.getSharpResizeOptionsWithoutDimensions(this.options.sharpResizeOptions),
       width: stat.width,
     };
 
-    if(metadata.format !== "svg" || !this.options.svgAllowUpscale) {
+    if(!("withoutEnlargement" in resizeOptions) && (metadata.format !== "svg" || !this.options.svgAllowUpscale)) {
       resizeOptions.withoutEnlargement = true;
     }
 

--- a/src/image.js
+++ b/src/image.js
@@ -358,6 +358,18 @@ export default class Image {
     return {};
   }
 
+  getSharpResizeOptions(stat, metadata) {
+    let resizeOptions = Object.assign({}, this.options.sharpResizeOptions, {
+      width: stat.width,
+    });
+
+    if(metadata.format !== "svg" || !this.options.svgAllowUpscale) {
+      resizeOptions.withoutEnlargement = true;
+    }
+
+    return resizeOptions;
+  }
+
   async getInput() {
     // internal cache
     if(!this.#input) {
@@ -415,12 +427,17 @@ export default class Image {
       "sharpWebpOptions",
       "sharpPngOptions",
       "sharpJpegOptions",
-      "sharpAvifOptions"
+      "sharpAvifOptions",
+      "sharpResizeOptions",
     ].sort();
 
     let hashObject = {};
     // The code currently assumes are keysToKeep are Object literals (see Util.getSortedObject)
     for(let key of keysToKeep) {
+      if(key === "sharpResizeOptions" && (!this.options[key] || Object.keys(this.options[key]).length === 0)) {
+        continue;
+      }
+
       if(this.options[key]) {
         hashObject[key] = Util.getSortedObject(this.options[key]);
       }
@@ -710,15 +727,7 @@ export default class Image {
 
         if(!isTransformResize) {
           if(stat.width < sharpMetadata.width || (this.options.svgAllowUpscale && sharpMetadata.format === "svg")) {
-            let resizeOptions = {
-              width: stat.width
-            };
-
-            if(sharpMetadata.format !== "svg" || !this.options.svgAllowUpscale) {
-              resizeOptions.withoutEnlargement = true;
-            }
-
-            sharpInstance.resize(resizeOptions);
+            sharpInstance.resize(this.getSharpResizeOptions(stat, sharpMetadata));
           }
         }
 
@@ -927,4 +936,3 @@ export default class Image {
     return img.statsByDimensionsSync(width, height);
   }
 }
-

--- a/test/test.js
+++ b/test/test.js
@@ -785,7 +785,6 @@ test("sharpResizeOptions should not override Eleventy Image dimensions", async t
       width: 10,
       height: 10,
       kernel: "nearest",
-      withoutReduction: true,
     },
   });
 
@@ -795,6 +794,16 @@ test("sharpResizeOptions should not override Eleventy Image dimensions", async t
   t.is(stats.jpeg[0].height, 199);
   t.is(outputMetadata.width, 300);
   t.true(outputMetadata.height > 10);
+});
+
+test("sharpResizeOptions should allow withoutEnlargement option", t => {
+  let image = new Image("./test/bio-2017.jpg", {
+    sharpResizeOptions: {
+      withoutEnlargement: false,
+    },
+  });
+
+  t.false(image.getSharpResizeOptions({ width: 300 }, { format: "jpeg" }).withoutEnlargement);
 });
 
 test("statsSync and eleventyImage output comparison", async t => {

--- a/test/test.js
+++ b/test/test.js
@@ -730,6 +730,20 @@ test("empty sharpResizeOptions should be ignored in hashing", t => {
   t.is(stats.jpeg[0].url, "/img/KkPMmHd3hP-1280.jpeg");
 });
 
+test("dimension sharpResizeOptions should be ignored in hashing", t => {
+  let stats = eleventyImage.statsSync("./test/bio-2017.jpg", {
+    widths: [1280],
+    sharpResizeOptions: {
+      width: 10,
+      height: 10,
+      withoutEnlargement: true,
+      withoutReduction: true,
+    }
+  });
+
+  t.is(stats.jpeg[0].url, "/img/KkPMmHd3hP-1280.jpeg");
+});
+
 test("sharpResizeOptions should apply to resize output and hash", async t => {
   let defaultStats = await eleventyImage("./test/bio-2017.jpg", {
     widths: [64],
@@ -760,7 +774,7 @@ test("sharpResizeOptions should apply to resize output and hash", async t => {
   t.true(pixelmatch(defaultRaw, nearestRaw, null, stats.jpeg[0].width, stats.jpeg[0].height, { threshold: 0.15 }) > 0);
 });
 
-test("sharpResizeOptions should not override Eleventy Image width", async t => {
+test("sharpResizeOptions should not override Eleventy Image dimensions", async t => {
   let stats = await eleventyImage("./test/bio-2017.jpg", {
     widths: [300],
     formats: ["jpeg"],
@@ -769,14 +783,18 @@ test("sharpResizeOptions should not override Eleventy Image width", async t => {
     useCache: false,
     sharpResizeOptions: {
       width: 10,
+      height: 10,
       kernel: "nearest",
+      withoutReduction: true,
     },
   });
 
   let outputMetadata = await sharp(stats.jpeg[0].buffer).metadata();
 
   t.is(stats.jpeg[0].width, 300);
+  t.is(stats.jpeg[0].height, 199);
   t.is(outputMetadata.width, 300);
+  t.true(outputMetadata.height > 10);
 });
 
 test("statsSync and eleventyImage output comparison", async t => {

--- a/test/test.js
+++ b/test/test.js
@@ -796,16 +796,6 @@ test("sharpResizeOptions should not override Eleventy Image dimensions", async t
   t.true(outputMetadata.height > 10);
 });
 
-test("sharpResizeOptions should allow withoutEnlargement option", t => {
-  let image = new Image("./test/bio-2017.jpg", {
-    sharpResizeOptions: {
-      withoutEnlargement: false,
-    },
-  });
-
-  t.false(image.getSharpResizeOptions({ width: 300 }, { format: "jpeg" }).withoutEnlargement);
-});
-
 test("statsSync and eleventyImage output comparison", async t => {
   let statsSync = eleventyImage.statsSync("./test/bio-2017.jpg", {
     widths: [399],

--- a/test/test.js
+++ b/test/test.js
@@ -721,6 +721,64 @@ test("widths array should be ignored in hashing", t => {
   t.is(stats2.jpeg[1].url, "/img/KkPMmHd3hP-600.jpeg");
 });
 
+test("empty sharpResizeOptions should be ignored in hashing", t => {
+  let stats = eleventyImage.statsSync("./test/bio-2017.jpg", {
+    widths: [1280],
+    sharpResizeOptions: {}
+  });
+
+  t.is(stats.jpeg[0].url, "/img/KkPMmHd3hP-1280.jpeg");
+});
+
+test("sharpResizeOptions should apply to resize output and hash", async t => {
+  let defaultStats = await eleventyImage("./test/bio-2017.jpg", {
+    widths: [64],
+    formats: ["jpeg"],
+    outputDir: "./test/img/",
+    dryRun: true,
+    useCache: false,
+  });
+
+  let stats = await eleventyImage("./test/bio-2017.jpg", {
+    widths: [64],
+    formats: ["jpeg"],
+    outputDir: "./test/img/",
+    dryRun: true,
+    useCache: false,
+    sharpResizeOptions: {
+      kernel: "nearest",
+    },
+  });
+
+  t.is(stats.jpeg[0].width, 64);
+  t.is(stats.jpeg[0].height, 42);
+  t.not(stats.jpeg[0].outputPath, path.join("test/img/KkPMmHd3hP-64.jpeg"));
+
+  let defaultRaw = await sharp(defaultStats.jpeg[0].buffer).ensureAlpha().toFormat(sharp.format.raw).toBuffer();
+  let nearestRaw = await sharp(stats.jpeg[0].buffer).ensureAlpha().toFormat(sharp.format.raw).toBuffer();
+
+  t.true(pixelmatch(defaultRaw, nearestRaw, null, stats.jpeg[0].width, stats.jpeg[0].height, { threshold: 0.15 }) > 0);
+});
+
+test("sharpResizeOptions should not override Eleventy Image width", async t => {
+  let stats = await eleventyImage("./test/bio-2017.jpg", {
+    widths: [300],
+    formats: ["jpeg"],
+    outputDir: "./test/img/",
+    dryRun: true,
+    useCache: false,
+    sharpResizeOptions: {
+      width: 10,
+      kernel: "nearest",
+    },
+  });
+
+  let outputMetadata = await sharp(stats.jpeg[0].buffer).metadata();
+
+  t.is(stats.jpeg[0].width, 300);
+  t.is(outputMetadata.width, 300);
+});
+
 test("statsSync and eleventyImage output comparison", async t => {
   let statsSync = eleventyImage.statsSync("./test/bio-2017.jpg", {
     widths: [399],

--- a/test/test.js
+++ b/test/test.js
@@ -730,7 +730,7 @@ test("empty sharpResizeOptions should be ignored in hashing", t => {
   t.is(stats.jpeg[0].url, "/img/KkPMmHd3hP-1280.jpeg");
 });
 
-test("dimension sharpResizeOptions should be ignored in hashing", t => {
+test("dimension sharpResizeOptions should be included in hashing", t => {
   let stats = eleventyImage.statsSync("./test/bio-2017.jpg", {
     widths: [1280],
     sharpResizeOptions: {
@@ -741,7 +741,7 @@ test("dimension sharpResizeOptions should be ignored in hashing", t => {
     }
   });
 
-  t.is(stats.jpeg[0].url, "/img/KkPMmHd3hP-1280.jpeg");
+  t.not(stats.jpeg[0].url, "/img/KkPMmHd3hP-1280.jpeg");
 });
 
 test("sharpResizeOptions should apply to resize output and hash", async t => {


### PR DESCRIPTION
Adds support for passing Sharp resize options. Notably, since Sharp now supports "Magic Kernel Sharp" downsizing kernel, that is more computationally efficient than the default Lanczos-3 kernel, it may be beneficial to be able to choose the algorithm.

This is a followup PR for reverted https://github.com/11ty/image/pull/322:
* backwards-compatible hash filenames (if the new option is not used, hashes remain the same)
* added appropriate tests, all tests pass